### PR TITLE
Added overload for `AuthenticationUtils.LoadSigningKey`

### DIFF
--- a/Mastercard.Developer.OAuth1Signer.Core/Utils/AuthenticationUtils.cs
+++ b/Mastercard.Developer.OAuth1Signer.Core/Utils/AuthenticationUtils.cs
@@ -11,13 +11,24 @@ namespace Mastercard.Developer.OAuth1Signer.Core.Utils
     public static class AuthenticationUtils
     {
         /// <summary>
-        /// Load a RSA key out of a PKCS#12 container.
+        /// Load an RSA key out of a PKCS#12 container.
         /// </summary>
         public static RSA LoadSigningKey(string pkcs12KeyFilePath, string signingKeyAlias, string signingKeyPassword,
             X509KeyStorageFlags keyStorageFlags = X509KeyStorageFlags.DefaultKeySet)
         {
             if (pkcs12KeyFilePath == null) throw new ArgumentNullException(nameof(pkcs12KeyFilePath));
             var signingCertificate = new X509Certificate2(pkcs12KeyFilePath, signingKeyPassword, keyStorageFlags);
+            return signingCertificate.GetRSAPrivateKey();
+        }
+
+        /// <summary>
+        /// Load an RSA key out of a PKCS#12 container.
+        /// </summary>
+        public static RSA LoadSigningKey(byte[] pkcs12RawData, string signingKeyPassword,
+            X509KeyStorageFlags keyStorageFlags = X509KeyStorageFlags.DefaultKeySet)
+        {
+            if (pkcs12RawData == null) throw new ArgumentNullException(nameof(pkcs12RawData));
+            var signingCertificate = new X509Certificate2(pkcs12RawData, signingKeyPassword, keyStorageFlags);
             return signingCertificate.GetRSAPrivateKey();
         }
     }

--- a/Mastercard.Developer.OAuth1Signer.Tests/NetCore/Utils/AuthenticationUtilsTest.cs
+++ b/Mastercard.Developer.OAuth1Signer.Tests/NetCore/Utils/AuthenticationUtilsTest.cs
@@ -1,5 +1,8 @@
-﻿using System.Security.Cryptography.X509Certificates;
+﻿using System.IO;
+using System.Security.Cryptography.X509Certificates;
+
 using Mastercard.Developer.OAuth1Signer.Core.Utils;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Mastercard.Developer.OAuth1Signer.Tests.NetCore.Utils
@@ -18,6 +21,24 @@ namespace Mastercard.Developer.OAuth1Signer.Tests.NetCore.Utils
             // WHEN
             const X509KeyStorageFlags flags = X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.Exportable; // https://github.com/dotnet/corefx/issues/14745
             var privateKey = AuthenticationUtils.LoadSigningKey(keyContainerPath, keyAlias, keyPassword, flags);
+
+            // THEN
+            Assert.AreEqual(2048, privateKey.KeySize);
+            Assert.AreEqual("RSA", privateKey.KeyExchangeAlgorithm);
+        }
+
+        [TestMethod]
+        public void TestLoadSigningKey_WithValidByteArray_ShouldReturnKey()
+        {
+            // GIVEN
+            const string keyContainerPath = "./_Resources/test_key_container.p12";
+            const string keyPassword = "Password1";
+
+            var p12Bytes = File.ReadAllBytes(keyContainerPath);
+
+            // WHEN
+            const X509KeyStorageFlags flags = X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.Exportable; // https://github.com/dotnet/corefx/issues/14745
+            var privateKey = AuthenticationUtils.LoadSigningKey(p12Bytes, keyPassword, flags);
 
             // THEN
             Assert.AreEqual(2048, privateKey.KeySize);


### PR DESCRIPTION
Added overload for `AuthenticationUtils.LoadSigningKey` that takes the cert data as a byte array.