### PR TITLE
Percent encode OAuth parameters during parameter normalization

### DIFF
--- a/Mastercard.Developer.OAuth1Signer.Core/OAuth.cs
+++ b/Mastercard.Developer.OAuth1Signer.Core/OAuth.cs
@@ -112,7 +112,7 @@ namespace Mastercard.Developer.OAuth1Signer.Core
             var sortedParameters = new SortedDictionary<string, List<string>>(queryParameters, StringComparer.Ordinal);
             foreach (var oauthParameter in oauthParameters)
             {
-                sortedParameters[oauthParameter.Key] = new List<string> { oauthParameter.Value };
+                sortedParameters[ToUriRfc3986(oauthParameter.Key)] = new List<string> { ToUriRfc3986(oauthParameter.Value) };
             }
 
             // Build the OAuth parameter string 

--- a/Mastercard.Developer.OAuth1Signer.Tests/NetCore2/OAuthTest.cs
+++ b/Mastercard.Developer.OAuth1Signer.Tests/NetCore2/OAuthTest.cs
@@ -204,7 +204,7 @@ namespace Mastercard.Developer.OAuth1Signer.Tests.NetCore2
             };
             var oauthParamString = OAuth.GetOAuthParamString(queryParameters, oauthParameters);
             var actualSignatureBaseString = OAuth.GetSignatureBaseString("https://api.mastercard.com", method, oauthParamString);
-            const string expectedSignatureBaseString = "POST&https%3A%2F%2Fapi.mastercard.com&first_param%3Dothervalue%26first_param%3Dvalue%26oauth_body_hash%3Dbody%2Fhash%26oauth_nonce%3Drandomnonce%26param2%3Dhello";
+            const string expectedSignatureBaseString = "POST&https%3A%2F%2Fapi.mastercard.com&first_param%3Dothervalue%26first_param%3Dvalue%26oauth_body_hash%3Dbody%252Fhash%26oauth_nonce%3Drandomnonce%26param2%3Dhello";
             Assert.AreEqual(expectedSignatureBaseString, actualSignatureBaseString);
         }
 
@@ -234,7 +234,7 @@ namespace Mastercard.Developer.OAuth1Signer.Tests.NetCore2
             };
             var oauthParamString = OAuth.GetOAuthParamString(queryParameters, oauthParameters);
             var actualSignatureBaseString = OAuth.GetSignatureBaseString(OAuth.GetBaseUriString(uri), method, oauthParamString);
-            const string expectedSignatureBaseString = "POST&https%3A%2F%2Fsandbox.api.mastercard.com%2Ffraud%2Fmerchant%2Fv1%2Ftermination-inquiry&Format%3DXML%26PageLength%3D10%26PageOffset%3D0%26oauth_body_hash%3Dh2Pd7zlzEZjZVIKB4j94UZn%2FxxoR3RoCjYQ9%2FJdadGQ%3D%26oauth_consumer_key%3Dxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx%26oauth_nonce%3D1111111111111111111%26oauth_signature_method%3DRSA-SHA256%26oauth_timestamp%3D1111111111%26oauth_version%3D1.0";
+            const string expectedSignatureBaseString = "POST&https%3A%2F%2Fsandbox.api.mastercard.com%2Ffraud%2Fmerchant%2Fv1%2Ftermination-inquiry&Format%3DXML%26PageLength%3D10%26PageOffset%3D0%26oauth_body_hash%3Dh2Pd7zlzEZjZVIKB4j94UZn%252FxxoR3RoCjYQ9%252FJdadGQ%253D%26oauth_consumer_key%3Dxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx%26oauth_nonce%3D1111111111111111111%26oauth_signature_method%3DRSA-SHA256%26oauth_timestamp%3D1111111111%26oauth_version%3D1.0";
             Assert.AreEqual(expectedSignatureBaseString, actualSignatureBaseString);
         }
 

--- a/Mastercard.Developer.OAuth1Signer.Tests/NetCore2/OAuthTest.cs
+++ b/Mastercard.Developer.OAuth1Signer.Tests/NetCore2/OAuthTest.cs
@@ -256,5 +256,28 @@ namespace Mastercard.Developer.OAuth1Signer.Tests.NetCore2
                 Assert.AreEqual(16, nonce.Length);
             });
         }
+
+        [TestMethod]
+        public void TestGetOAuthParamString_ShouldPercentEncodeOAuthParameters()
+        {
+            // This supports `Appendix A.1. Example PUT Request` from https://tools.ietf.org/id/draft-eaton-oauth-bodyhash-00.html#parameter
+            // per 3.4.1.3.2.  Parameters Normalization from https://datatracker.ietf.org/doc/html/rfc5849#section-3.4.1.3.2
+            const string method = "PUT";
+            var queryParameters = new Dictionary<string, List<string>>();
+            var oauthParameters = new Dictionary<string, string>
+            {
+                { "oauth_body_hash", "Lve95gjOVATpfV8EL5X4nxwjKHE=" },
+                { "oauth_consumer_key", "consumer" },
+                { "oauth_nonce", "10369470270925" },
+                { "oauth_signature_method", "HMAC-SHA1" },
+                { "oauth_timestamp", "1236874236" },
+                { "oauth_token", "token" },
+                { "oauth_version", "1.0" }
+            };
+            var oauthParamString = OAuth.GetOAuthParamString(queryParameters, oauthParameters);
+            var actualSignatureBaseString = OAuth.GetSignatureBaseString("http://www.example.com/resource", method, oauthParamString);
+            const string expectedSignatureBaseString = "PUT&http%3A%2F%2Fwww.example.com%2Fresource&oauth_body_hash%3DLve95gjOVATpfV8EL5X4nxwjKHE%253D%26oauth_consumer_key%3Dconsumer%26oauth_nonce%3D10369470270925%26oauth_signature_method%3DHMAC-SHA1%26oauth_timestamp%3D1236874236%26oauth_token%3Dtoken%26oauth_version%3D1.0";
+            Assert.AreEqual(expectedSignatureBaseString, actualSignatureBaseString);
+        }
     }
 }


### PR DESCRIPTION
#### Link to issue/feature request: https://github.com/Mastercard/oauth1-signer-csharp/issues/14

#### Description
Adds percent encoding for oauth parameters, similar to the old Mastercard/sdk-core-csharp repository.

